### PR TITLE
Ajuste no setup.py, adicionado a pasta de log e realizado ajuste no logging.ini-TEMPLATE

### DIFF
--- a/proc/logging.ini-TEMPLATE
+++ b/proc/logging.ini-TEMPLATE
@@ -27,7 +27,7 @@ propagate=0
 class=handlers.TimedRotatingFileHandler
 level=DEBUG
 formatter=Formatter
-args=('log/pcitations.log', 'D', 1, 5, None, False, False)
+args=('../log/pcitations.log', 'D', 1, 5, None, False, False)
 
 [handler_consoleHandler]
 class=StreamHandler

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import os
 from setuptools import setup, find_packages
 
 here = os.path.abspath(os.path.dirname(__file__))
-with open(os.path.join(here, 'README.txt')) as f:
+with open(os.path.join(here, 'README.md')) as f:
     README = f.read()
 with open(os.path.join(here, 'CHANGES.txt')) as f:
     CHANGES = f.read()


### PR DESCRIPTION
Ajustes:

1. Correção do arquivo de README.txt para README.md no setup.py
2. Criado a pasta de log vazia
3. Realizado ajuste do path do arquivo do log no logging.ini da pasta tools
4. Corrigido o bug: https://github.com/scieloorg/citedby/issues/48