### PR TITLE
Adicionado sniff no cluster de ES, ajustes nos arquivos .ini, setup.py e requirements.txt 

### DIFF
--- a/citedby/__init__.py
+++ b/citedby/__init__.py
@@ -16,7 +16,8 @@ def main(global_config, **settings):
     hosts = aslist(settings['elasticsearch_host'])
 
     def add_index(request):
-        return ICitation(hosts=hosts)
+        return ICitation(hosts=hosts, sniff_on_start=True,
+                         sniff_on_connection_fail=True)
 
     cache_region.configure('dogpile.cache.pylibmc',
             expiration_time=int(settings['memcached_expiration_time']),

--- a/development-TEMPLATE.ini
+++ b/development-TEMPLATE.ini
@@ -22,7 +22,7 @@ debugtoolbar.intercept_redirects = false
 
 # ES hosts
 #Use host:9200 or host
-elasticsearch_host=homolog.esa.scielo.org:9200 homolog.esb.scielo.org:9200
+elasticsearch_host=esa.scielo.org:9200 esb.scielo.org:9200 esc.scielo.org:9200
 
 # Memcached configuration
 # Expiration time: 1 hour = 3600s / 24 hours = 86400s / 30 days = 2592000s

--- a/production-TEMPLATE.ini
+++ b/production-TEMPLATE.ini
@@ -14,7 +14,7 @@ pyramid.default_locale_name = en
 
 #ES hosts
 #Use host:9200 or host
-elasticsearch_host=homolog.esa.scielo.org:9200 homolog.esb.scielo.org:9200
+elasticsearch_host=esa.scielo.org:9200 esb.scielo.org:9200 esc.scielo.org:9200
 
 #Memcached configuration
 #Expiration time: 1 hour = 3600s / 24 hours = 86400s / 30 days = 2592000s

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,10 +3,12 @@ paster
 nose
 waitress
 gunicorn
--e git+git://github.com/scieloorg/xylose.git#egg=xylose
 requests
 elasticsearch
-progressbar2==2.6.7
+progressbar2
+python-memcached
 dogpile
 dogpile.cache
 pylibmc
+pyramid_debugtoolbar
+-e git+git://github.com/scieloorg/xylose.git#egg=xylose

--- a/setup.py
+++ b/setup.py
@@ -1,26 +1,22 @@
 import os
-
+import pip
+from pip.req import parse_requirements
 from setuptools import setup, find_packages
 
 here = os.path.abspath(os.path.dirname(__file__))
-with open(os.path.join(here, 'README.md')) as f:
-    README = f.read()
-with open(os.path.join(here, 'CHANGES.txt')) as f:
-    CHANGES = f.read()
 
-requires = [
-    'pyramid',
-    'pyramid_chameleon',
-    'pyramid_debugtoolbar',
-    'waitress',
-    ]
+install_reqs = parse_requirements('requirements.txt',
+                                  session=pip.download.PipSession())
+
+requires = [str(ir.req) for ir in install_reqs]
 
 test_requires = requires+['mocker']
 
 setup(name='citedby',
       version='1.0',
-      description='Tool that retrieves documents citing a given PID, DOI or document title.',
-      long_description=README + '\n\n' + CHANGES,
+      description='API RESTFul to retrieve citations from SciELO articles to a given DOI, Article Title or SciELO ID',
+      long_description=open(os.path.join(here, 'README.md')).read() + '\n\n' +
+                       open(os.path.join(here, 'CHANGES.txt')).read(),
       classifiers=[
         "Intended Audience :: Developers",
         "License :: OSI Approved :: BSD License",
@@ -32,9 +28,9 @@ setup(name='citedby',
         ],
       author='SciELO',
       author_email='scielo-dev@googlegroups.com',
-      license='BSD 2 -clause',
-      url='http://docs.scielo.org',
-      keywords='scielo citedby',
+      license='BSD 2-Clause',
+      url='http://docs.scielo.org/projects/citedby/en/latest/',
+      keywords='SciELO CitedBy API RESTFul',
       packages=find_packages(),
       include_package_data=True,
       zip_safe=False,


### PR DESCRIPTION
Ref.: tk #55 

1. Adicionado o sniff na instância do ES 
2. Ajustes nos arquivos .ini **homolog.*.scielo.org -> es*.scielo.org**
3. Adicionado a capacidade de o setup.py conhecer os requisitos do arquivo requirements.txt
